### PR TITLE
use upstream rev including my fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 
 [dependencies]
 libc = "*"
-rust-htslib = { git = "https://github.com/10XGenomics/rust-htslib.git", branch = "lh/fix-serde-l_extranull", default-features = false, features = ["serde"] }
+rust-htslib = { git = "https://github.com/rust-bio/rust-htslib.git", rev = "6a93aa47", default-features = false, features = ["serde"] }
 failure = "*"
 failure_derive = "*"
 


### PR DESCRIPTION
is version 22.0 with my fix and some dep upgrades.

Until we get the next release version this is required.