### PR TITLE
create_bam_header too restrictive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,12 +147,13 @@ impl BwaReference {
     }
 
     pub fn create_bam_header(&self) -> Header {
-        let mut header = Header::new();
+        self.populate_bam_header(Header::new())
+    }
 
+    pub fn populate_bam_header(&self, mut header: Header) -> Header {
         for (ref contig_name, &len) in self.contig_names.iter().zip(self.contig_lengths.iter()) {
             add_ref_to_bam_header(&mut header, &contig_name, len);
         }
-
         header
     }
 }


### PR DESCRIPTION
I would like to begin my bam header with an HD record...but bam::Header won't let you insert a record at an arbitrary location.

Also this is my bad--I should have foreseen the original API being too restrictive.