### PR TITLE
Add license specifiers to Cargo.tomls.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bwa"
 version = "0.1.0"
 authors = ["Patrick Marks <patrick@10xgenomics.com>"]
+license = "MIT"
 
 [workspace]
 

--- a/bwa-sys/Cargo.toml
+++ b/bwa-sys/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Patrick Marks <patrick@10xgenomics.com>"]
 build = "build.rs"
 links = "bwa"
+license = "Apache-2.0"
 
 [dependencies]
 libc = "*"


### PR DESCRIPTION
Use MIT license for the bwa crate, but use Apache-2 for bwa-sys, to
match the license in the branch of bwa that it links against.