### PR TITLE
Replace `failure` with `thiserror`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bwa"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Patrick Marks <patrick@10xgenomics.com>"]
 license = "MIT"
 
@@ -8,10 +8,9 @@ license = "MIT"
 
 [dependencies]
 libc = "*"
-failure = "*"
-failure_derive = "*"
 rust-htslib = { version = ">=0.35.2", default-features = false, features = ["serde_feature"] }
 bwa-sys = { path = "bwa-sys" }
+thiserror = "1"
 
 [profile.release]
 debug = 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,14 +22,10 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-extern crate failure;
 extern crate libc;
 extern crate rust_htslib;
 
-#[macro_use]
-extern crate failure_derive;
-
-use failure::Error;
+extern crate thiserror;
 
 use std::ffi::{CStr, CString};
 use std::path::Path;
@@ -97,8 +93,8 @@ impl BwaSettings {
     }
 }
 
-#[derive(Debug, Fail)]
-#[fail(display = "{}", _0)]
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
 pub struct ReferenceError(String);
 
 /// A BWA reference object to perform alignments to.
@@ -227,7 +223,7 @@ unsafe impl Sync for BwaAligner {}
 
 impl BwaAligner {
     /// Load a BWA reference from the given path and use default BWA settings and paired-end structure.
-    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<BwaAligner, Error> {
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<BwaAligner, ReferenceError> {
         let bwa_ref = BwaReference::open(path)?;
         Ok(BwaAligner::new(
             bwa_ref,


### PR DESCRIPTION
Replaces the deprecated `failure` crate with `thiserror`.

`ReferenceError` is now derived with `thiserror::Error` instead of `failure::Fail`